### PR TITLE
Removed usesCleartextTraffic from AndroidManifest

### DIFF
--- a/MembraneRTC/src/main/AndroidManifest.xml
+++ b/MembraneRTC/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 <uses-permission android:name="android.permission.CAMERA" />
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-<application android:usesCleartextTraffic="true">
+<application>
     <service
         android:name="org.membraneframework.rtc.media.screencast.ScreencastService"
         android:enabled="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".RoomActivity"
             android:exported="false"


### PR DESCRIPTION
If the sample app requires clear text traffic to be enabled to function it should be configured using network config in the app itself and not in the core SDK.