### PR TITLE
Fix RC in ICE negotiation

### DIFF
--- a/MembraneRTC/build.gradle
+++ b/MembraneRTC/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.github.dsrees:JavaPhoenixClient:1.0.0'
     api 'com.github.webrtc-sdk:android:93.4577.01'
-    implementation 'androidx.core:core:1.7.0'
+    implementation 'androidx.core:core:1.8.0'
 }
 
 afterEvaluate {

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/events/Event.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/events/Event.kt
@@ -181,7 +181,7 @@ data class PeerUpdated(val type: ReceivableEventType, val data: Data): Receivabl
 data class OfferData(val type: ReceivableEventType, val data: Data): ReceivableEvent() {
     data class TurnServer(val username: String, val password: String, val serverAddr: String, val serverPort: UInt, val transport: String)
 
-    data class Data(val iceTransportPolicy: String, val integratedTurnServers: List<TurnServer>, val tracksTypes: Map<String, Int>)
+    data class Data(val integratedTurnServers: List<TurnServer>, val tracksTypes: Map<String, Int>)
 }
 
 data class TracksAdded(val type: ReceivableEventType, val data: Data): ReceivableEvent() {


### PR DESCRIPTION
In most cases Android needed about 30-40 seconds to establish the connection to the SFU.
It turned out that we have a RC and we sometimes try to set candidate before SDP answer. 
While server sends messages in a proper order, android sdk runs `onSdpAnswer` and `onRemoteCandidate` in separate corutines which results in RC.