### PR TITLE
Fix removing track from PeerConnection

### DIFF
--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -169,7 +169,7 @@ constructor(
 
         // remove a sender that is associated with given track
         val rtcTrack = track.rtcTrack()
-        pc.transceivers.find { it.sender.track() == rtcTrack }?.sender?.let {
+        pc.transceivers.find { it.sender.track()?.id() == rtcTrack.id() }?.sender?.let {
             pc.removeTrack(it)
         }
 


### PR DESCRIPTION
I can't make it to call `pc.removeTrack` without those changes :thinking: 

This fixes incorrect SDP offer after "removing a track" i.e. now track is marked as inactive. 