### PR TITLE
Fixed screen-share track creation

### DIFF
--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -141,10 +141,7 @@ constructor(
         }
 
         localTracks.add(screencastTrack)
-        localPeer = localPeer.withTrack(screencastTrack.id(), metadata + mapOf(
-            "type" to "screensharing",
-            "user_id" to (localPeer.metadata["displayName"] ?: "")
-        ))
+        localPeer = localPeer.withTrack(screencastTrack.id(), metadata)
 
         coroutineScope.launch {
             screencastTrack.startForegroundService(null, null)


### PR DESCRIPTION
When the screen-share track was getting created it was trying to copy in the track type and metadata manually instead of just passing them through like when the audio and video tracks get created.