### PR TITLE
[MV-153] Fix aspect ratio issues

### DIFF
--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/ui/VideoTextureViewRenderer.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/ui/VideoTextureViewRenderer.kt
@@ -217,8 +217,11 @@ class VideoTextureViewRenderer : TextureView, SurfaceHolder.Callback, SurfaceTex
             val drawnFrameWidth: Int
             val drawnFrameHeight: Int
 
+            var width = this.width
+            var height = this.height
+
             when (scalingType) {
-                ScalingType.SCALE_ASPECT_FILL ->
+                ScalingType.SCALE_ASPECT_FILL -> {
                     if (frameAspectRatio > layoutAspectRatio) {
                         drawnFrameWidth = (rotatedFrameHeight * layoutAspectRatio).toInt()
                         drawnFrameHeight = rotatedFrameHeight
@@ -226,16 +229,16 @@ class VideoTextureViewRenderer : TextureView, SurfaceHolder.Callback, SurfaceTex
                         drawnFrameWidth = rotatedFrameWidth
                         drawnFrameHeight = (rotatedFrameWidth / layoutAspectRatio).toInt()
                     }
+                    // Aspect ratio of the drawn frame and the view is the same.
+                    width = Math.min(width, drawnFrameWidth)
+                    height = Math.min(height, drawnFrameHeight)
+                }
 
                 else -> {
-                    drawnFrameWidth = rotatedFrameWidth
-                    drawnFrameHeight = rotatedFrameHeight
+                    width = rotatedFrameWidth
+                    height = rotatedFrameHeight
                 }
             }
-
-            // Aspect ratio of the drawn frame and the view is the same.
-            val width = Math.min(width, drawnFrameWidth)
-            val height = Math.min(height, drawnFrameHeight)
 
             logD(
                 "updateSurfaceSize() "

--- a/app/src/main/java/com/dscout/membranevideoroomdemo/RoomActivity.kt
+++ b/app/src/main/java/com/dscout/membranevideoroomdemo/RoomActivity.kt
@@ -145,7 +145,7 @@ class RoomActivity : AppCompatActivity() {
                         ParticipantCard(
                             participant = it,
                             videoViewLayout = VideoViewLayout.FIT,
-                            size = Size(150f, 150 * (16f / 9f))
+                            size = Size(200f, 200 * (16f / 9f))
                         )
                     }
 
@@ -204,15 +204,18 @@ fun ParticipantCard(
         ) {
             onClick?.invoke()
         }
+            .clip(RoundedCornerShape(10.dp))
+            .height(size.height.dp)
+            .width(size.width.dp)
+            .background(Blue.darker(0.7f))
     ) {
         ParticipantVideoView(
             participant = participant,
             videoViewLayout = videoViewLayout ,
             modifier = Modifier
-                .padding(10.dp)
-                .clip(RoundedCornerShape(10.dp))
-                .height(size.height.dp)
-                .width(size.width.dp)
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .fillMaxHeight()
                 .background(Blue.darker(0.7f))
         )
 


### PR DESCRIPTION
When setting scaling type to FIT, the video is often distorted. For example, when the view is 960x540 and video is 1280x720, the drawn frame would be calculated as 964x720 changing the aspect ratio. I guess this portion of the code:
```
// Aspect ratio of the drawn frame and the view is the same.
width = Math.min(width, drawnFrameWidth)
height = Math.min(height, drawnFrameHeight)
```
should go to the FILL case, in the FIT case we just draw the whole video.