### PR TITLE
Improve connection errors

### DIFF
--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -371,11 +371,15 @@ constructor(
     }
 
     override fun onError(error: EventTransportError) {
-        listener.onError(MembraneRTCError.Transport(error.message ?: "unknown transport message"))
+        if (error is EventTransportError.ConnectionError) {
+            listener.onError(MembraneRTCError.Transport(error.reason))
+        } else {
+            listener.onError(MembraneRTCError.Transport(error.message ?: "unknown transport message"))
+        }
     }
 
     override fun onClose() {
-        listener.onError(MembraneRTCError.Transport("transport has been closed"))
+        Timber.i("Transport has been closed")
     }
 
     fun setTargetTrackEncoding(trackId: String, encoding: TrackEncoding) {


### PR DESCRIPTION
This PR solves the following issues:
- When disconnecting from the backend gracefully using `disconnect()` after disconnecting we get an error `"transport has been closed"`. Transport being disconnected is expected, it's not an error and it's misleading.
- When we're unexpectedly disconnected from the backend (internet connection or backend is down) we get a couple of errors: `"unknown transport message"` and `"transport has been closed"`. Now we're reading and returning the reason for an error and the error should be more descriptive.