### PR TITLE
[MV-363] Fix some race conditions and memory leaks

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -5,10 +5,9 @@ import android.content.Intent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.membraneframework.rtc.events.OfferData
 import org.membraneframework.rtc.media.*
 import org.membraneframework.rtc.models.*
@@ -51,6 +50,7 @@ constructor(
     private val trackContexts = HashMap<String, TrackContext>()
 
     private val localTracks = mutableListOf<LocalTrack>()
+    private val localTracksMutex = Mutex()
 
     private val coroutineScope: CoroutineScope =
         ClosableCoroutineScope(SupervisorJob() + defaultDispatcher)
@@ -86,7 +86,9 @@ constructor(
     fun disconnect() {
         coroutineScope.launch {
             rtcEngineCommunication.disconnect()
-            localTracks.forEach { it.stop() }
+            localTracksMutex.withLock {
+                localTracks.forEach { it.stop() }
+            }
             peerConnectionManager.close()
         }
     }
@@ -136,7 +138,7 @@ constructor(
         mediaProjectionPermission: Intent,
         videoParameters: VideoParameters,
         metadata: Metadata = mapOf(),
-        onEnd: () -> Unit
+        onEnd: (() -> Unit)?
     ): LocalScreencastTrack {
         val screencastTrack = LocalScreencastTrack.create(
             context,
@@ -145,9 +147,9 @@ constructor(
             mediaProjectionPermission,
             videoParameters
         ) { track ->
-            onEnd()
-
-            removeTrack(track.id())
+            if (onEnd != null) {
+                onEnd()
+            }
         }
 
         localTracks.add(screencastTrack)
@@ -170,22 +172,27 @@ constructor(
     }
 
     fun removeTrack(trackId: String): Boolean {
-        val track = localTracks.find { it.id() == trackId } ?: run {
-            Timber.e("removeTrack: Can't find track to remove")
-            return false
+        runBlocking {
+            localTracksMutex.withLock {
+                val track = localTracks.find { it.id() == trackId } ?: run {
+                    Timber.e("removeTrack: Can't find track to remove")
+                    return@runBlocking false
+                }
+
+                peerConnectionManager.removeTrack(track.id())
+
+                localTracks.remove(track)
+                localPeer = localPeer.withoutTrack(trackId)
+                track.stop()
+
+                coroutineScope.launch {
+                    rtcEngineCommunication.renegotiateTracks()
+                }
+
+                return@runBlocking true
+            }
         }
-
-        peerConnectionManager.removeTrack(track.id())
-
-        localTracks.remove(track)
-        localPeer = localPeer.withoutTrack(trackId)
-        track.stop()
-
-        coroutineScope.launch {
-            rtcEngineCommunication.renegotiateTracks()
-        }
-
-        return true
+        return false
     }
 
     fun updatePeerMetadata(peerMetadata: Metadata) {
@@ -264,12 +271,14 @@ constructor(
     override fun onOfferData(integratedTurnServers: List<OfferData.TurnServer>, tracksTypes: Map<String, Int>) {
         coroutineScope.launch {
             try {
-                val offer = peerConnectionManager.getSdpOffer(integratedTurnServers, tracksTypes, localTracks)
-                rtcEngineCommunication.sdpOffer(
-                    offer.description,
-                    localPeer.trackIdToMetadata,
-                    offer.midToTrackIdMapping
-                )
+                localTracksMutex.withLock {
+                    val offer = peerConnectionManager.getSdpOffer(integratedTurnServers, tracksTypes, localTracks)
+                    rtcEngineCommunication.sdpOffer(
+                        offer.description,
+                        localPeer.trackIdToMetadata,
+                        offer.midToTrackIdMapping
+                    )
+                }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to create an sdp offer")
             }
@@ -278,7 +287,25 @@ constructor(
 
     override fun onSdpAnswer(type: String, sdp: String, midToTrackId: Map<String, String>) {
         coroutineScope.launch {
-            peerConnectionManager.onSdpAnswer(sdp, midToTrackId, localTracks)
+            peerConnectionManager.onSdpAnswer(sdp, midToTrackId)
+
+            localTracksMutex.withLock {
+                // temporary workaround, the backend doesn't add ~ in sdp answer
+                localTracks.forEach { localTrack ->
+                    if (localTrack.rtcTrack().kind() != "video") return@forEach
+                    var config: SimulcastConfig? = null
+                    if (localTrack is LocalVideoTrack) {
+                        config = localTrack.videoParameters.simulcastConfig
+                    } else if (localTrack is LocalScreencastTrack) {
+                        config = localTrack.videoParameters.simulcastConfig
+                    }
+                    listOf(TrackEncoding.L, TrackEncoding.M, TrackEncoding.H).forEach {
+                        if (config?.activeEncodings?.contains(it) == false) {
+                            peerConnectionManager.setTrackEncoding(localTrack.id(), it, false)
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/MembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/MembraneRTC.kt
@@ -94,7 +94,7 @@ private constructor(
         mediaProjectionPermission: Intent,
         videoParameters: VideoParameters,
         metadata: Metadata,
-        onEnd: () -> Unit
+        onEnd: (() -> Unit)? = null
     ): LocalScreencastTrack? {
         return client.createScreencastTrack(mediaProjectionPermission, videoParameters, metadata, onEnd)
     }

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
@@ -261,8 +261,7 @@ internal class PeerConnectionManager
 
     suspend fun onSdpAnswer(
         sdp: String,
-        midToTrackId: Map<String, String>,
-        localTracks: List<LocalTrack>
+        midToTrackId: Map<String, String>
     ) {
         val pc = peerConnection ?: return
 
@@ -275,21 +274,6 @@ internal class PeerConnectionManager
 
         pc.setRemoteDescription(answer).onSuccess {
             drainCandidates()
-            // temporary workaround, the backend doesn't add ~ in sdp answer
-            localTracks.forEach { localTrack ->
-                if (localTrack.rtcTrack().kind() != "video") return@forEach
-                var config: SimulcastConfig? = null
-                if (localTrack is LocalVideoTrack) {
-                    config = localTrack.videoParameters.simulcastConfig
-                } else if (localTrack is LocalScreencastTrack) {
-                    config = localTrack.videoParameters.simulcastConfig
-                }
-                listOf(TrackEncoding.L, TrackEncoding.M, TrackEncoding.H).forEach {
-                    if (config?.activeEncodings?.contains(it) == false) {
-                        setTrackEncoding(localTrack.id(), it, false)
-                    }
-                }
-            }
         }
     }
 

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/RTCEngineCommunication.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/RTCEngineCommunication.kt
@@ -84,6 +84,7 @@ constructor(
     }
 
     override fun onEvent(event: ReceivableEvent) {
+        Timber.d("EVENT: " + event)
         when (event) {
             is OfferData -> engineListener.onOfferData(event.data.integratedTurnServers, event.data.tracksTypes)
             is PeerAccepted -> engineListener.onPeerAccepted(event.data.id, event.data.peersInRoom)

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/RTCEngineCommunication.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/RTCEngineCommunication.kt
@@ -84,7 +84,6 @@ constructor(
     }
 
     override fun onEvent(event: ReceivableEvent) {
-        Timber.d("EVENT: " + event)
         when (event) {
             is OfferData -> engineListener.onOfferData(event.data.integratedTurnServers, event.data.tracksTypes)
             is PeerAccepted -> engineListener.onPeerAccepted(event.data.id, event.data.peersInRoom)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,13 +6,13 @@ apply plugin: 'kotlin-parcelize'
 
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.dscout.membranevideoroomdemo"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 

--- a/app/src/main/java/com/dscout/membranevideoroomdemo/viewmodels/RoomViewModel.kt
+++ b/app/src/main/java/com/dscout/membranevideoroomdemo/viewmodels/RoomViewModel.kt
@@ -56,12 +56,7 @@ class RoomViewModel(
     )
     val screencastSimulcastConfig = MutableStateFlow(
         SimulcastConfig(
-            enabled = true,
-            activeEncodings = listOf(
-                TrackEncoding.L,
-                TrackEncoding.M,
-                TrackEncoding.H
-            )
+            enabled = false
         )
     )
 
@@ -358,14 +353,7 @@ class RoomViewModel(
         val dimensions = videoParameters.dimensions.flip()
         videoParameters = videoParameters.copy(
             dimensions = dimensions,
-            simulcastConfig = screencastSimulcastConfig.value,
-            maxBitrate = TrackBandwidthLimit.SimulcastBandwidthLimit(
-                mapOf(
-                    "l" to TrackBandwidthLimit.BandwidthLimit(150),
-                    "m" to TrackBandwidthLimit.BandwidthLimit(500),
-                    "h" to TrackBandwidthLimit.BandwidthLimit(1500)
-                )
-            )
+            simulcastConfig = screencastSimulcastConfig.value
         )
 
         localScreencastTrack = room.value?.createScreencastTrack(
@@ -375,9 +363,7 @@ class RoomViewModel(
                 "type" to "screensharing",
                 "user_id" to (localDisplayName ?: "")
             )
-        ) {
-            stopScreencast()
-        }
+        )
 
         localScreencastTrack?.let {
             mutableParticipants[localScreencastId!!] = Participant(
@@ -400,7 +386,6 @@ class RoomViewModel(
 
                 emitParticipants()
             }
-
             localScreencastTrack = null
         }
     }


### PR DESCRIPTION
When you turn screencast on and off you can reproduce various crashes.

First of all when I analysed the code I figured out we're stopping the screencast many times: when user presses the stop button, then twice when screencast ends. That's unnecessary and messes up a lot (in between stopping the screencast user is able to start the screencast). Now it's stopped just once when user presses the button.

Starting and stopping the screencast can happen on different threads. Starting and stopping the screencast at the same time is a bad idea. I've added a mutex to make sure we're either starting or stopping the screencast.

Actually nearly everything can happen on a different thread: the user interaction happens on the main thread, the engine communication happens on the other thread, the screencast is started on another thread and some functions in peer connection are asynchronous so we need to run them in coroutines which may be yet another thread. So the `InternalMembraneRTC` and `PeerConnectionManager` classes are used on different threads. It may happen that we're removing a track in peer connection on the main thread because user stopped the screencast and we're getting sdp offer and reading peer connection transceivers on websocket thread which leads to crash.

The best idea I've come up with is to use mutexes so that only one thread at once can access local tracks and peer connection. We're using them already in some places. It's not ideal though:
- some functions that were synchronous before are now asynchronous. Nothing changes in the api, but now changes made to peer connection may not be applied immediately. But it shouldn't change much: for example for `setTrackBandwidth` function we don't care much if the bandwidth is set immediately or in a short period of time.
- you need to be really careful with using mutexes on kotlin. They're non-reentrant and you can easily cause a deadlock. Thankfully only `PeerConnectionManager` has access to peer connection and it manages the lock.

Also there is one crash that I guess is due to a memory leak. I added some missing `dispose()` calls but it still crashes. I'll make a separate issue for it. 

Those changes fixed most of the crashes when restarting screencast. For the ones that's left I'll make separate issues.