### PR TITLE
[RTC-279] Allow to create tracks immediately after onConnect callback

### DIFF
--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
@@ -51,6 +51,8 @@ internal class PeerConnectionManager
     private val coroutineScope: CoroutineScope =
         ClosableCoroutineScope(SupervisorJob())
 
+    private var streamIds: List<String> = listOf(UUID.randomUUID().toString())
+
     private fun getSendEncodingsFromConfig(simulcastConfig: SimulcastConfig): List<RtpParameters.Encoding> {
         val sendEncodings = Constants.simulcastEncodings()
         simulcastConfig.activeEncodings.forEach {
@@ -59,7 +61,11 @@ internal class PeerConnectionManager
         return sendEncodings
     }
 
-    suspend fun addTrack(track: LocalTrack, streamIds: List<String>) {
+    suspend fun addTrack(track: LocalTrack) {
+        addTrack(track, streamIds)
+    }
+
+    private suspend fun addTrack(track: LocalTrack, streamIds: List<String>) {
         val videoParameters =
             (track as? LocalVideoTrack)?.videoParameters ?: (track as? LocalScreencastTrack)?.videoParameters
 
@@ -207,8 +213,6 @@ internal class PeerConnectionManager
         peerConnectionMutex.withLock {
             this@PeerConnectionManager.peerConnection = pc
         }
-
-        val streamIds = listOf(UUID.randomUUID().toString())
 
         localTracks.forEach {
             addTrack(it, streamIds)

--- a/app/src/main/java/com/dscout/membranevideoroomdemo/viewmodels/RoomViewModel.kt
+++ b/app/src/main/java/com/dscout/membranevideoroomdemo/viewmodels/RoomViewModel.kt
@@ -101,7 +101,7 @@ class RoomViewModel(
                 listener = this@RoomViewModel
             )
 
-            setupTracksAndJoinRoom()
+            room.value?.connect(mapOf("displayName" to (localDisplayName ?: "")))
         }
     }
 
@@ -206,7 +206,7 @@ class RoomViewModel(
         }
     }
 
-    private fun setupTracksAndJoinRoom() {
+    private fun setupTracks() {
         room.value?.let {
             localAudioTrack = it.createAudioTrack(
                 mapOf(
@@ -238,8 +238,6 @@ class RoomViewModel(
                 )
             )
 
-            it.connect(mapOf("displayName" to (localDisplayName ?: "")))
-
             isCameraOn.value = localVideoTrack?.enabled() ?: false
             isMicrophoneOn.value = localAudioTrack?.enabled() ?: false
 
@@ -252,8 +250,6 @@ class RoomViewModel(
                 participant.videoTrack?.id(),
                 mapOf("active" to isCameraOn.value)
             )
-
-            emitParticipants()
         }
     }
 
@@ -270,6 +266,7 @@ class RoomViewModel(
             )
         }
 
+        setupTracks()
         emitParticipants()
     }
 


### PR DESCRIPTION
For consistency with the web version
btw renamed `endpointConnectionManager` back to `peerConnectionManager`