### PR TITLE
Remove dagger (dependency injection library)

### DIFF
--- a/MembraneRTC/build.gradle
+++ b/MembraneRTC/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-kapt"
     id 'maven-publish'
     id 'org.jetbrains.dokka'
 }
@@ -49,8 +48,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.dagger:dagger:2.38'
-    kapt 'com.google.dagger:dagger-compiler:2.38'
     implementation deps.coroutines.lib
     implementation deps.timber
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -30,10 +30,11 @@ internal class InternalMembraneRTC
         private val listener: MembraneRTCListener,
         private val defaultDispatcher: CoroutineDispatcher,
         private val eglBase: EglBase,
-        private val context: Context,
+        private val context: Context
     ) : RTCEngineListener, PeerConnectionListener {
         private val rtcEngineCommunication = RTCEngineCommunication(this)
-        private val peerConnectionFactoryWrapper = PeerConnectionFactoryWrapper(createOptions, RTCModule.audioDeviceModule(context), eglBase, context)
+        private val peerConnectionFactoryWrapper =
+            PeerConnectionFactoryWrapper(createOptions, RTCModule.audioDeviceModule(context), eglBase, context)
         private val peerConnectionManager = PeerConnectionManager(this, peerConnectionFactoryWrapper)
 
         private var localEndpoint: Endpoint =

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -38,9 +38,8 @@ internal class InternalMembraneRTC
         private val defaultDispatcher: CoroutineDispatcher,
         private val eglBase: EglBase,
         private val context: Context,
-        rtcEngineCommunicationFactory: RTCEngineCommunication.RTCEngineCommunicationFactory,
     ) : RTCEngineListener, PeerConnectionListener {
-        private val rtcEngineCommunication = rtcEngineCommunicationFactory.create(this)
+        private val rtcEngineCommunication = RTCEngineCommunication(this)
         private val peerConnectionFactoryWrapper = PeerConnectionFactoryWrapper(createOptions, RTCModule.audioDeviceModule(context), eglBase, context)
         private val peerConnectionManager = PeerConnectionManager(this, peerConnectionFactoryWrapper)
 

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -8,6 +8,7 @@ import dagger.assisted.AssistedInject
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.membraneframework.rtc.dagger.RTCModule
 import org.membraneframework.rtc.events.OfferData
 import org.membraneframework.rtc.media.*
 import org.membraneframework.rtc.models.EncodingReason
@@ -38,10 +39,9 @@ internal class InternalMembraneRTC
         private val eglBase: EglBase,
         private val context: Context,
         rtcEngineCommunicationFactory: RTCEngineCommunication.RTCEngineCommunicationFactory,
-        peerConnectionFactoryWrapperFactory: PeerConnectionFactoryWrapper.PeerConnectionFactoryWrapperFactory
     ) : RTCEngineListener, PeerConnectionListener {
         private val rtcEngineCommunication = rtcEngineCommunicationFactory.create(this)
-        private val peerConnectionFactoryWrapper = peerConnectionFactoryWrapperFactory.create(createOptions)
+        private val peerConnectionFactoryWrapper = PeerConnectionFactoryWrapper(createOptions, RTCModule.audioDeviceModule(context), eglBase, context)
         private val peerConnectionManager = PeerConnectionManager(this, peerConnectionFactoryWrapper)
 
         private var localEndpoint: Endpoint =

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -2,9 +2,6 @@ package org.membraneframework.rtc
 
 import android.content.Context
 import android.content.Intent
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -28,13 +25,9 @@ import timber.log.Timber
 import java.util.*
 
 internal class InternalMembraneRTC
-    @AssistedInject
     constructor(
-        @Assisted
         private val createOptions: CreateOptions,
-        @Assisted
         private val listener: MembraneRTCListener,
-        @Assisted
         private val defaultDispatcher: CoroutineDispatcher,
         private val eglBase: EglBase,
         private val context: Context,
@@ -64,7 +57,6 @@ internal class InternalMembraneRTC
             }
         }
 
-        @AssistedFactory
         interface Factory {
             fun create(
                 createOptions: CreateOptions,

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/InternalMembraneRTC.kt
@@ -38,16 +38,11 @@ internal class InternalMembraneRTC
         private val eglBase: EglBase,
         private val context: Context,
         rtcEngineCommunicationFactory: RTCEngineCommunication.RTCEngineCommunicationFactory,
-        peerConnectionManagerFactory: PeerConnectionManager.PeerConnectionManagerFactory,
         peerConnectionFactoryWrapperFactory: PeerConnectionFactoryWrapper.PeerConnectionFactoryWrapperFactory
     ) : RTCEngineListener, PeerConnectionListener {
         private val rtcEngineCommunication = rtcEngineCommunicationFactory.create(this)
         private val peerConnectionFactoryWrapper = peerConnectionFactoryWrapperFactory.create(createOptions)
-        private val peerConnectionManager =
-            peerConnectionManagerFactory.create(
-                this,
-                peerConnectionFactoryWrapper
-            )
+        private val peerConnectionManager = PeerConnectionManager(this, peerConnectionFactoryWrapper)
 
         private var localEndpoint: Endpoint =
             Endpoint(id = "", type = "webrtc", metadata = mapOf(), tracks = mapOf())

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/MembraneRTC.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/MembraneRTC.kt
@@ -3,7 +3,7 @@ package org.membraneframework.rtc
 import android.content.Context
 import android.content.Intent
 import kotlinx.coroutines.Dispatchers
-import org.membraneframework.rtc.dagger.DaggerMembraneRTCComponent
+import org.membraneframework.rtc.dagger.RTCModule
 import org.membraneframework.rtc.media.*
 import org.membraneframework.rtc.models.RTCStats
 import org.membraneframework.rtc.utils.Metadata
@@ -259,15 +259,7 @@ class MembraneRTC
             ): MembraneRTC {
                 val ctx = appContext.applicationContext
 
-                val component =
-                    DaggerMembraneRTCComponent
-                        .factory()
-                        .create(ctx)
-
-                val client =
-                    component
-                        .membraneRTCFactory()
-                        .create(options, listener, Dispatchers.Default)
+                val client = InternalMembraneRTC(options, listener, Dispatchers.Default, RTCModule.eglBase(), ctx)
 
                 return MembraneRTC(client)
             }

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionFactoryWrapper.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionFactoryWrapper.kt
@@ -1,22 +1,17 @@
 package org.membraneframework.rtc
 
 import android.content.Context
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 import org.membraneframework.rtc.media.SimulcastVideoEncoderFactoryWrapper
 import org.webrtc.*
 import org.webrtc.audio.AudioDeviceModule
 
 internal class PeerConnectionFactoryWrapper
-    @AssistedInject
     constructor(
-        @Assisted private val createOptions: CreateOptions,
+        private val createOptions: CreateOptions,
         audioDeviceModule: AudioDeviceModule,
         eglBase: EglBase,
         appContext: Context
     ) {
-        @AssistedFactory
         interface PeerConnectionFactoryWrapperFactory {
             fun create(createOptions: CreateOptions): PeerConnectionFactoryWrapper
         }

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
@@ -22,7 +22,6 @@ import java.util.*
 import kotlin.math.pow
 
 internal class PeerConnectionManager
-
     constructor(
         private val peerConnectionListener: PeerConnectionListener,
         private val peerConnectionFactory: PeerConnectionFactoryWrapper

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/PeerConnectionManager.kt
@@ -1,8 +1,5 @@
 package org.membraneframework.rtc
 
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
@@ -25,12 +22,11 @@ import java.util.*
 import kotlin.math.pow
 
 internal class PeerConnectionManager
-    @AssistedInject
+
     constructor(
-        @Assisted private val peerConnectionListener: PeerConnectionListener,
-        @Assisted private val peerConnectionFactory: PeerConnectionFactoryWrapper
+        private val peerConnectionListener: PeerConnectionListener,
+        private val peerConnectionFactory: PeerConnectionFactoryWrapper
     ) : PeerConnection.Observer {
-        @AssistedFactory
         interface PeerConnectionManagerFactory {
             fun create(
                 listener: PeerConnectionListener,

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/RTCEngineCommunication.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/RTCEngineCommunication.kt
@@ -1,9 +1,6 @@
 package org.membraneframework.rtc
 
 import com.google.gson.reflect.TypeToken
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 import org.membraneframework.rtc.events.*
 import org.membraneframework.rtc.models.Endpoint
 import org.membraneframework.rtc.utils.Metadata
@@ -12,12 +9,9 @@ import timber.log.Timber
 import kotlin.math.roundToLong
 
 internal class RTCEngineCommunication
-    @AssistedInject
     constructor(
-        @Assisted
         private val engineListener: RTCEngineListener
     ) {
-        @AssistedFactory
         interface RTCEngineCommunicationFactory {
             fun create(listener: RTCEngineListener): RTCEngineCommunication
         }

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/dagger/MembraneRTCComponent.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/dagger/MembraneRTCComponent.kt
@@ -1,30 +1,21 @@
 package org.membraneframework.rtc.dagger
 
 import android.content.Context
-import dagger.BindsInstance
-import dagger.Component
 import org.membraneframework.rtc.InternalMembraneRTC
 import org.webrtc.EglBase
 import org.webrtc.audio.AudioDeviceModule
-import javax.inject.Singleton
 
-@Singleton
-@Component(
-    modules = [
-        RTCModule::class
-    ]
-)
+
 internal interface MembraneRTCComponent {
-    fun membraneRTCFactory(): InternalMembraneRTC.Factory
+    fun membraneRTCFactory(): InternalMembraneRTC
 
     fun eglBase(): EglBase
 
     fun audioDeviceModule(): AudioDeviceModule
 
-    @Component.Factory
     interface Factory {
         fun create(
-            @BindsInstance appContext: Context
+            appContext: Context
         ): MembraneRTCComponent
     }
 }

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/dagger/MembraneRTCComponent.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/dagger/MembraneRTCComponent.kt
@@ -5,7 +5,6 @@ import org.membraneframework.rtc.InternalMembraneRTC
 import org.webrtc.EglBase
 import org.webrtc.audio.AudioDeviceModule
 
-
 internal interface MembraneRTCComponent {
     fun membraneRTCFactory(): InternalMembraneRTC
 
@@ -14,8 +13,6 @@ internal interface MembraneRTCComponent {
     fun audioDeviceModule(): AudioDeviceModule
 
     interface Factory {
-        fun create(
-            appContext: Context
-        ): MembraneRTCComponent
+        fun create(appContext: Context): MembraneRTCComponent
     }
 }

--- a/MembraneRTC/src/main/java/org/membraneframework/rtc/dagger/RTCModule.kt
+++ b/MembraneRTC/src/main/java/org/membraneframework/rtc/dagger/RTCModule.kt
@@ -1,24 +1,16 @@
 package org.membraneframework.rtc.dagger
 
 import android.content.Context
-import dagger.Module
-import dagger.Provides
 import org.webrtc.*
 import org.webrtc.audio.AudioDeviceModule
 import org.webrtc.audio.JavaAudioDeviceModule
 import timber.log.Timber
-import javax.inject.Singleton
 
-@Module
 internal object RTCModule {
-    @Singleton
-    @Provides
     fun eglBase(): EglBase {
         return EglBase.create()
     }
 
-    @Singleton
-    @Provides
     fun audioDeviceModule(appContext: Context): AudioDeviceModule {
         val audioRecordErrorCallback =
             object : JavaAudioDeviceModule.AudioRecordErrorCallback {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ ext {
             androidx_lifecycle: "2.4.0",
             preference_version: "1.2.0",
             autoService       : '1.0.1',
-            dagger            : "2.27",
             groupie           : "2.9.0",
             junit             : "4.13.2",
             junitJupiter      : "5.5.0",


### PR DESCRIPTION
I want to remove this library for few reasons:
- it seems to be used only to create instance of one class
- it adds complexity in library managment
But mostly because I want to merge `membrane-webrtc-android`  with `client-sdk-android`. And removing `dagger` will just simplify all that.